### PR TITLE
Lab2

### DIFF
--- a/src/kvsrv/client.go
+++ b/src/kvsrv/client.go
@@ -60,7 +60,7 @@ func (ck *Clerk) Get(key string) string {
 func (ck *Clerk) PutAppend(key string, value string, op string) string {
 	// You will have to modify this function.
 
-	args := PutAppendArgs{Key: key, Value: value}
+	args := PutAppendArgs{Key: key, Value: value, IdempotencyKey: randstring(32)}
 	reply := PutAppendReply{}
 
 	for !ck.server.Call("KVServer."+op, &args, &reply) {

--- a/src/kvsrv/client.go
+++ b/src/kvsrv/client.go
@@ -1,9 +1,11 @@
 package kvsrv
 
-import "6.5840/labrpc"
-import "crypto/rand"
-import "math/big"
+import (
+	"crypto/rand"
+	"math/big"
 
+	"6.5840/labrpc"
+)
 
 type Clerk struct {
 	server *labrpc.ClientEnd
@@ -36,8 +38,15 @@ func MakeClerk(server *labrpc.ClientEnd) *Clerk {
 // arguments. and reply must be passed as a pointer.
 func (ck *Clerk) Get(key string) string {
 
+	args := GetArgs{Key: key}
+	reply := GetReply{}
+
+	for !ck.server.Call("KVServer.Get", &args, &reply) {
+		DPrintf("retrying op Get")
+	}
+
 	// You will have to modify this function.
-	return ""
+	return reply.Value
 }
 
 // shared by Put and Append.
@@ -50,7 +59,15 @@ func (ck *Clerk) Get(key string) string {
 // arguments. and reply must be passed as a pointer.
 func (ck *Clerk) PutAppend(key string, value string, op string) string {
 	// You will have to modify this function.
-	return ""
+
+	args := PutAppendArgs{Key: key, Value: value}
+	reply := PutAppendReply{}
+
+	for !ck.server.Call("KVServer."+op, &args, &reply) {
+		DPrintf("retrying op " + op)
+	}
+
+	return reply.Value
 }
 
 func (ck *Clerk) Put(key string, value string) {

--- a/src/kvsrv/client.go
+++ b/src/kvsrv/client.go
@@ -10,6 +10,7 @@ import (
 type Clerk struct {
 	server *labrpc.ClientEnd
 	// You will have to modify this struct.
+	clientID int64
 }
 
 func nrand() int64 {
@@ -23,6 +24,7 @@ func MakeClerk(server *labrpc.ClientEnd) *Clerk {
 	ck := new(Clerk)
 	ck.server = server
 	// You'll have to add code here.
+	ck.clientID = nrand()
 	return ck
 }
 
@@ -60,7 +62,7 @@ func (ck *Clerk) Get(key string) string {
 func (ck *Clerk) PutAppend(key string, value string, op string) string {
 	// You will have to modify this function.
 
-	args := PutAppendArgs{Key: key, Value: value, IdempotencyKey: randstring(32)}
+	args := PutAppendArgs{Key: key, Value: value, IdempotencyKey: randstring(32), ClientID: ck.clientID}
 	reply := PutAppendReply{}
 
 	for !ck.server.Call("KVServer."+op, &args, &reply) {

--- a/src/kvsrv/common.go
+++ b/src/kvsrv/common.go
@@ -7,6 +7,7 @@ type PutAppendArgs struct {
 	// You'll have to add definitions here.
 	// Field names must start with capital letters,
 	// otherwise RPC will break.
+	IdempotencyKey string
 }
 
 type PutAppendReply struct {

--- a/src/kvsrv/common.go
+++ b/src/kvsrv/common.go
@@ -8,6 +8,7 @@ type PutAppendArgs struct {
 	// Field names must start with capital letters,
 	// otherwise RPC will break.
 	IdempotencyKey string
+	ClientID       int64
 }
 
 type PutAppendReply struct {

--- a/src/kvsrv/server.go
+++ b/src/kvsrv/server.go
@@ -18,7 +18,17 @@ type KVServer struct {
 	mu sync.Mutex
 
 	// Your definitions here.
-	data map[string]string
+	data              map[string]string
+	processedRequests map[string]string
+}
+
+func (kv *KVServer) hasAlreadyProcessedRequestSavingOldValue(idempotencyKey string, oldValue string) bool {
+	_, ok := kv.processedRequests[idempotencyKey]
+	if ok {
+		return true
+	}
+	kv.processedRequests[idempotencyKey] = oldValue
+	return false
 }
 
 func (kv *KVServer) Get(args *GetArgs, reply *GetReply) {
@@ -32,6 +42,9 @@ func (kv *KVServer) Put(args *PutAppendArgs, reply *PutAppendReply) {
 	// Your code here.
 	kv.mu.Lock()
 	defer kv.mu.Unlock()
+	if kv.hasAlreadyProcessedRequestSavingOldValue(args.IdempotencyKey, "") { // no return, so no need for oldValue.
+		return
+	}
 	kv.data[args.Key] = args.Value
 }
 
@@ -40,6 +53,10 @@ func (kv *KVServer) Append(args *PutAppendArgs, reply *PutAppendReply) {
 	kv.mu.Lock()
 	defer kv.mu.Unlock()
 	oldValue := kv.data[args.Key]
+	if kv.hasAlreadyProcessedRequestSavingOldValue(args.IdempotencyKey, oldValue) {
+		reply.Value = kv.processedRequests[args.IdempotencyKey]
+		return
+	}
 
 	kv.data[args.Key] += args.Value
 
@@ -51,6 +68,7 @@ func StartKVServer() *KVServer {
 
 	// You may need initialization code here.
 	kv.data = make(map[string]string)
+	kv.processedRequests = make(map[string]string)
 
 	return kv
 }

--- a/src/kvsrv/server.go
+++ b/src/kvsrv/server.go
@@ -14,30 +14,43 @@ func DPrintf(format string, a ...interface{}) (n int, err error) {
 	return
 }
 
-
 type KVServer struct {
 	mu sync.Mutex
 
 	// Your definitions here.
+	data map[string]string
 }
-
 
 func (kv *KVServer) Get(args *GetArgs, reply *GetReply) {
 	// Your code here.
+	kv.mu.Lock()
+	defer kv.mu.Unlock()
+	reply.Value = kv.data[args.Key]
 }
 
 func (kv *KVServer) Put(args *PutAppendArgs, reply *PutAppendReply) {
 	// Your code here.
+	kv.mu.Lock()
+	defer kv.mu.Unlock()
+	kv.data[args.Key] = args.Value
 }
 
 func (kv *KVServer) Append(args *PutAppendArgs, reply *PutAppendReply) {
 	// Your code here.
+	kv.mu.Lock()
+	defer kv.mu.Unlock()
+	oldValue := kv.data[args.Key]
+
+	kv.data[args.Key] += args.Value
+
+	reply.Value = oldValue
 }
 
 func StartKVServer() *KVServer {
 	kv := new(KVServer)
 
 	// You may need initialization code here.
+	kv.data = make(map[string]string)
 
 	return kv
 }

--- a/src/kvsrv/test_test.go
+++ b/src/kvsrv/test_test.go
@@ -596,7 +596,8 @@ func TestMemManyAppends(t *testing.T) {
 	runtime.ReadMemStats(&st)
 	m1 := st.HeapAlloc
 	if m1 >= 3*MEM*N {
-		t.Fatalf("error: server using too much memory m0 %d m1 %d\n", m0, m1)
+		t.Fatalf("error: server using too much memory m0 %d m1 %d >= %d. above by %d\n",
+			m0, m1, 3*MEM*N, m1-(3*MEM*N))
 	}
 
 	log.Printf("m0 %d m1 %d\n", m0, m1)


### PR DESCRIPTION
```
❰chase❙~/Dev/learn/6.5840/src/kvsrv(git:lab2)❱✔≻ go test -race
Test: one client ...
  ... Passed -- t  3.2 nrpc 13091 ops 13091
Test: many clients ...
  ... Passed -- t  3.4 nrpc 43065 ops 43065
Test: unreliable net, many clients ...
  ... Passed -- t  3.4 nrpc  1116 ops  892
Test: concurrent append to same key, unreliable ...
  ... Passed -- t  0.2 nrpc    62 ops   52
Test: memory use get ...
  ... Passed -- t  4.6 nrpc     6 ops    0
Test: memory use put ...
  ... Passed -- t  4.4 nrpc     2 ops    0
Test: memory use append ...
  ... Passed -- t  8.7 nrpc     2 ops    0
Test: memory use many put clients ...
  ... Passed -- t 24.2 nrpc 100000 ops    0
Test: memory use many get client ...
  ... Passed -- t 22.8 nrpc 100001 ops    0
Test: memory use many appends ...
2024/05/28 16:27:49 m0 326704 m1 2339456
  ... Passed -- t  2.6 nrpc  1000 ops    0
PASS
ok      6.5840/kvsrv    80.514s
```